### PR TITLE
Db shouldn't be a singleton

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,15 +3,15 @@
   "version": "0.0.1",
   "description": "MongoDB connection wrapper",
   "main": "index.js",
-  "scripts": { },
+  "scripts": {},
   "repository": {
     "type": "git",
     "url": "https://github.com/DemocracyOS/democracyos-db.git"
   },
   "dependencies": {
     "debug": "^2.1.1",
-    "mongoose": "3.8.24",
-    "muri": "1.0.0"
+    "muri": "1.0.0",
+    "semver": "^4.3.1"
   },
   "keywords": [
     "mongodb",


### PR DESCRIPTION
Need this to use [mockgoose](https://www.npmjs.com/package/mockgoose) module on container apps. It allows to share a required `mongoose` variable between the container app and this module.

Also, has the pro that avoids the duplication of `mongoose` module on the different `package.json`'s.

This commit changes the interface from this:

```
var db = require('democracyos-db');
```

to this:

```
var mongoose = require('mongoose');
var db = require('democracyos-db')(mongoose);
```
